### PR TITLE
Changed the ProMotion dependency version to match the current version

### DIFF
--- a/ProMotion-map.gemspec
+++ b/ProMotion-map.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(spec)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "ProMotion", "~> 2.0.0"
+  spec.add_dependency "ProMotion", "~> 2.0.0.rc4"
   spec.add_development_dependency "motion-stump", "~> 0.3"
   spec.add_development_dependency "motion-redgreen", "~> 0.1"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
ProMotion is currently at 2.0.0.rc4 (clearsightstudio/ProMotion@637e6fac598ae55ff8879893e2349ff0ea16e892), but ProMotion-map currently requires 2.0, which can't be found. This change modifies the dependency to require rc4.
