### PR TITLE
Adds the ability to include the user pin in the zoom_to_fit_annotations method

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,9 +177,9 @@ Adds more than one annotation at a time to the map.
 
 Removes all annotations from the `MapScreen`.
 
-#### zoom_to_fit_annotations(animated=true, include_user=false)
+#### zoom_to_fit_annotations({animated:true, include_user:false})
 
-Changes the zoom and center point of the `MapScreen` to fit all the annotations. Passing `include_user` as true will cause the zoom to not only include the annotations from `annotation_data` but also the user pin in the zoom region calculation.
+Changes the zoom and center point of the `MapScreen` to fit all the annotations. Passing `include_user` as `true` will cause the zoom to not only include the annotations from `annotation_data` but also the user pin in the zoom region calculation.
 
 #### set_region(region, animated=true)
 

--- a/lib/ProMotion/map/map_screen_module.rb
+++ b/lib/ProMotion/map/map_screen_module.rb
@@ -178,8 +178,12 @@ module ProMotion
     end
 
     # TODO: Why is this so complex?
-    def zoom_to_fit_annotations(animated=true, include_user = false)
-      ann = include_user ? (annotations + [user_annotation]).compact : annotations
+    def zoom_to_fit_annotations(args={})
+      # Preserve backwards compatibility
+      args = {animated: args} if args == true || args == false
+      args = {animated: true, include_user: false}.merge(args)
+
+      ann = args[:include_user] ? (annotations + [user_annotation]).compact : annotations
 
       #Don't attempt the rezoom of there are no pins
       return if ann.count == 0
@@ -211,7 +215,7 @@ module ProMotion
       region = MKCoordinateRegionMake(coord, span)
       fits = self.view.regionThatFits(region)
 
-      set_region(fits, animated:animated)
+      set_region(fits, animated: args[:animated])
     end
 
     def set_region(region, animated=true)


### PR DESCRIPTION
Nice for zooming into all annotations PLUS the user to fit the screen.

This should always be called after you know you have a user location on the screen, most likely inside the `on_user_location(location)` method. Otherwise, it ignores the user's location since it's still `nil`.
