### PR TITLE
Add support to detailCalloutAccessoryView

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ All possible properties:
     pin_color: :red, # Defaults to :red. Other options are :green or :purple or any MKPinAnnotationColor
     left_accessory: my_button,
     right_accessory: my_other_button,
+    detail_accessory: my_custom_view,
     action: :my_action, # Overrides :right_accessory
     action_button_type: UIButtonTypeContactAdd # Defaults to UIButtonTypeDetailDisclosure
 }
@@ -118,6 +119,8 @@ You may pass whatever properties you want in the annotation hash, but (`:longitu
 Use `:image` to specify a custom image. Pass in a string to conserve memory and it will be converted using `UIImage.imageNamed(your_string)`. If you pass in a `UIImage`, we'll use that, but keep in mind that there will be another unnecessary copy of the UIImage in memory.
 
 Use `:left_accessory` and `:right_accessory` to specify a custom accessory, like a button.
+
+Use `:detail_accessory` to specify a detail accessory that will be positioned below the title, any UIView will work. This will override `:subtitle`. Available from iOS 9.0.
 
 You can access annotation data you've arbitrarily stored in the hash by calling `annotation_instance.params[:your_param]`.
 

--- a/lib/ProMotion/map/map_screen_module.rb
+++ b/lib/ProMotion/map/map_screen_module.rb
@@ -163,6 +163,9 @@ module ProMotion
       if params[:right_accessory]
         view.rightCalloutAccessoryView = params[:right_accessory]
       end
+      if params[:detail_accessory]
+        view.detailCalloutAccessoryView = params[:detail_accessory]
+      end
 
       if params[:action]
         button_type = params[:action_button_type] || UIButtonTypeDetailDisclosure

--- a/spec/func_map_screen_spec.rb
+++ b/spec/func_map_screen_spec.rb
@@ -197,7 +197,7 @@ describe "ProMotion::TestMapScreen functionality" do
   end
 
   it "should allow setting a detailCalloutAccessoryView" do
-    img = UIImage.imageNamed("test.png")
+    img = UIImageView.alloc.initWithImage(UIImage.imageNamed("test.png"))
     ann = {
       longitude: -82.965972900392,
       latitude: 35.090648651124,

--- a/spec/func_map_screen_spec.rb
+++ b/spec/func_map_screen_spec.rb
@@ -196,6 +196,21 @@ describe "ProMotion::TestMapScreen functionality" do
     v.rightCalloutAccessoryView.should == btn
   end
 
+  it "should allow setting a detailCalloutAccessoryView" do
+    img = UIImage.imageNamed("test.png")
+    ann = {
+      longitude: -82.965972900392,
+      latitude: 35.090648651124,
+      title: "My Cool Image Pin",
+      detail_accessory: img
+    }
+    map_screen.add_annotation ann
+    annot = map_screen.annotations.last
+    annot.should.be.kind_of?(ProMotion::MapScreenAnnotation)
+    v = map_screen.annotation_view(map_screen.view, annot)
+    v.detailCalloutAccessoryView.should == img
+  end
+
   it "should call the correct action when set on an annotation" do
     ann = default_annotation.merge({
       action: :my_action


### PR DESCRIPTION
Add support to MKAnnotationView.detailCalloutAccessoryView, that was introduced in iOS 9.0.

Kind of related to #29 

[WWDC 2015 Session 206 - What's New in MapKit](https://developer.apple.com/videos/play/wwdc2015/206/) 
